### PR TITLE
Add moduleRoot option to include a module name in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ var wrap = require('gulp-wrap-amd');
 gulp.task('wrap', function() {
   gulp.src('./lib/*.js')
     .pipe(wrap({
-      deps: ['jade'], // dependency array
-      params: ['jade'], // params for callback
-      exports: 'jade' // variable to return
+      deps: ['jade'],          // dependency array
+      params: ['jade'],        // params for callback
+      exports: 'jade',         // variable to return
+      moduleRoot: 'templates/' // include a module name in the define() call, relative to moduleRoot
     }))
     .pipe(gulp.dest('./dist/'))
 });

--- a/index.js
+++ b/index.js
@@ -5,10 +5,15 @@ var clone = require('lodash').clone;
 var defaults = require('lodash').defaults;
 var isStream = require('gulp-util').isStream;
 var isBuffer = require('gulp-util').isBuffer;
+var path = require('path');
 
 var tmpl = require('./template').amd;
 
 function compile(contents, opts){
+  opts.name = typeof opts.moduleRoot == 'string'
+    ? path.relative(opts.moduleRoot, opts.file.path).slice(0, -path.extname(opts.file.path).length)
+    : null;
+    
   opts.contents = contents;
   return tmpl(opts);
 }
@@ -18,7 +23,8 @@ function getOptions(file, opts){
     deps: null,
     params: null,
     exports: null,
-    file: file
+    file: file,
+    moduleRoot: null
   });
 }
 

--- a/template.js
+++ b/template.js
@@ -29,6 +29,8 @@
     function print() { __p += __j.call(arguments, '') }
     with (obj) {
     __p += 'define(' +
+    ((__t = ( name ? JSON.stringify(name) + ',' : '' )) == null ? '' : __t) +
+    '' +
     ((__t = ( deps ? JSON.stringify(deps) + ',' : '' )) == null ? '' : __t) +
     'function(' +
     ((__t = ( (!deps ? ['require', 'exports', 'module'] : params || '').toString() )) == null ? '' : __t) +

--- a/templates/amd.jst
+++ b/templates/amd.jst
@@ -1,4 +1,4 @@
-define(<%= deps ? JSON.stringify(deps) + ',' : '' %>function(<%= (!deps ? ['require', 'exports', 'module'] : params || '').toString() %>){
+define(<%= name ? JSON.stringify(name) + ',' : '' %><%= deps ? JSON.stringify(deps) + ',' : '' %>function(<%= (!deps ? ['require', 'exports', 'module'] : params || '').toString() %>){
 <% if(exports){ %>
 <%= contents %>
 return <%= exports %>;

--- a/test/stream.js
+++ b/test/stream.js
@@ -20,7 +20,8 @@ var expected = _.template(jst, {
   deps: null,
   params: null,
   exports: null,
-  contents: fs.readFileSync(filePath)
+  contents: fs.readFileSync(filePath),
+  name: null
 });
 
 var file = new gutil.File({

--- a/test/test.js
+++ b/test/test.js
@@ -18,7 +18,8 @@ function expectStream(t, options){
     deps: null,
     params: null,
     exports: null,
-    contents: null
+    contents: null,
+    name: null
   });
   return es.map(function(file){
     options.contents = fs.readFileSync(file.path, 'utf-8');
@@ -92,5 +93,37 @@ test('should isolate the contents of the individual files', function(t){
     }))
     .pipe(expectStream(t, {
       deps: ['test']
+    }));
+});
+
+test('should include module name if moduleRoot option is given', function(t) {
+  t.plan(1);
+  
+  gulp.src(filename)
+    .pipe(task({
+      moduleRoot: './',
+      deps: ['jade'],
+      params: ['jade'],
+    }))
+    .pipe(expectStream(t, {
+      deps: ['jade'],
+      params: ['jade'],
+      name: 'fixtures/helloworld'
+    }));
+});
+
+test('module name should be relative to moduleRoot', function(t) {
+  t.plan(1);
+  
+  gulp.src(filename)
+    .pipe(task({
+      moduleRoot: 'fixtures/',
+      deps: ['jade'],
+      params: ['jade'],
+    }))
+    .pipe(expectStream(t, {
+      deps: ['jade'],
+      params: ['jade'],
+      name: 'helloworld'
     }));
 });


### PR DESCRIPTION
The module names are relative to `moduleRoot`. Useful if the next task is concatenating the modules together.
