### PR TITLE
platform agnostic for file path definition, to fix gulp-wrap-amd/issues/...

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ function compile(contents, opts){
   opts.name = null;
   if(typeof opts.moduleRoot === 'string'){
     opts.name = path.relative(opts.moduleRoot, opts.file.path).slice(0, -path.extname(opts.file.path).length);
+    // platform agnostic for file path definition
+    opts.name = opts.name.split(path.sep).join('/');
+
     if(opts.modulePrefix) {
       var prefix = opts.modulePrefix.indexOf('/') > -1 ? opts.modulePrefix : opts.modulePrefix + '/';
       opts.name = prefix + opts.name;


### PR DESCRIPTION
I have come up with solid solution to unify the platform filepath delimiter. It passes all tests. Do I need to add a test case for it? 