### PR TITLE
Bump up dependency and devDependency modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "repository": "https://github.com/phated/gulp-wrap-amd.git",
   "author": "Blaine Bublitz <blaine@iceddev.com>",
   "dependencies": {
-    "gulp-util": "~3.0",
-    "lodash": "~2.4.1",
-    "through2": "~0.5.1"
+    "gulp-util": "^3.0.4",
+    "lodash": "^3.5.0",
+    "through2": "^0.6.3"
   },
   "main": "index.js",
   "engines": {
@@ -23,9 +23,9 @@
     "compile": "lodash template=./templates/*.jst exports=node -o template.js -d"
   },
   "devDependencies": {
-    "tap": "~0.4.6",
-    "lodash-cli": "~2.4.1",
-    "gulp": "~3.8.6",
-    "gulp-jshint": "~1.7.1"
+    "tap": "^0.7.1",
+    "lodash-cli": "^3.5.0",
+    "gulp": "^3.8.11",
+    "gulp-jshint": "^1.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-wrap-amd",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Wrap files with an AMD wrapper",
   "keywords": [
     "gulpplugin",

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,8 @@ function expectStream(t, options){
   });
   return through.obj(function(file, enc, cb){
     options.contents = fs.readFileSync(file.path, 'utf-8');
-    var expected = _.template(jst, options);
+    var compiled = _.template(jst);
+    var expected = compiled(options);
     t.equals(expected, String(file.contents));
     cb();
   });


### PR DESCRIPTION
I have experienced some **npm warning** when I do `npm install` packages.

``` bash
npm WARN unmet dependency /Users/qma17/Desktop/repos/default/ts/node_modules/gulp-wrap-amd requires lodash@'~2.4.1' but will load
npm WARN unmet dependency /Users/qma17/Desktop/repos/default/ts/node_modules/lodash,
npm WARN unmet dependency which is version 3.5.0
```

I went ahead and updated all dependency and devDependency modules, fixed/passed all unit tests. And I also run this code in a couple of real projects that I am working on, and it works fine. 

Since it is a major bump of lodash, I also bump up the version to `v0.5.0`.
